### PR TITLE
Feat/45 and 68 address setup and validation

### DIFF
--- a/src/components/registration-form/registration-form.module.css
+++ b/src/components/registration-form/registration-form.module.css
@@ -33,7 +33,7 @@
   gap: 15px;
 }
 
-.singleAddressFlag {
+.checkboxLabel {
   display: flex;
   gap: 5px;
   justify-content: center;

--- a/src/components/registration-form/registration-form.module.css
+++ b/src/components/registration-form/registration-form.module.css
@@ -21,6 +21,25 @@
   font-size: 14px;
 }
 
+.registrationInput:focus {
+  border-color: #2281e6;
+  outline: none;
+  box-shadow: 0 0 5px #7697e6;
+}
+
+.addressContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.singleAddressFlag {
+  display: flex;
+  gap: 5px;
+  justify-content: center;
+  align-items: center;
+}
+
 .errorMessage {
   color: red;
   font-size: 12px;

--- a/src/components/registration-form/registration-form.module.css
+++ b/src/components/registration-form/registration-form.module.css
@@ -27,10 +27,29 @@
   box-shadow: 0 0 5px #7697e6;
 }
 
-.addressContainer {
+.formBlockContainer {
   display: flex;
   flex-direction: column;
   gap: 15px;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  padding: 2rem;
+  box-shadow: 0 2px 6px rgba(0 0 0 5%);
+}
+
+.mainInfoContainer {
+  background-color: #fff;
+  border-color: #ddd;
+}
+
+.shippingAddressContainer {
+  background-color: #e7f4ff;
+  border-color: #b3d8ff;
+}
+
+.billingAddressContainer {
+  background-color: #fff9e6;
+  border-color: #ffe9a8;
 }
 
 .checkboxLabel {

--- a/src/components/registration-form/registration-form.tsx
+++ b/src/components/registration-form/registration-form.tsx
@@ -79,6 +79,10 @@ export const RegistrationForm: FC = () => {
       {/* Shipping Address */}
       <div className={`${styles.shippingAddressContainer} ${styles.addressContainer}`}>
         <h3>Shipping Address</h3>
+        <label className={styles.defaultAddressCheckbox}>
+          <input type="checkbox" {...register('defaultShippingAddress')} />
+          Set this address as default shipping address
+        </label>
         <div className={styles.registrationInputContainer}>
           <input
             className={styles.registrationInput}
@@ -140,6 +144,10 @@ export const RegistrationForm: FC = () => {
       {!useSameAddress && (
         <div className={`${styles.billingAddressContainer} ${styles.addressContainer}`}>
           <h3>Billing Address</h3>
+          <label className={styles.defaultAddressCheckbox}>
+            <input type="checkbox" {...register('defaultBillingAddress')} />
+            Set this address as default billing address
+          </label>
           <div className={styles.registrationInputContainer}>
             <input
               className={styles.registrationInput}
@@ -206,8 +214,13 @@ export const mapFormDataToCustomerDraft = (data: FormData): CustomerDraft => {
   };
 
   const addresses = [shippingAddress];
-  let defaultShippingAddress = 0;
-  let defaultBillingAddress = 0;
+
+  let defaultShippingAddress: number | undefined;
+  let defaultBillingAddress: number | undefined;
+
+  if (data.defaultShippingAddress) {
+    defaultShippingAddress = 0;
+  }
 
   if (!data.useSameAddress && data.billingAddress.street) {
     const billingAddress = {
@@ -217,7 +230,12 @@ export const mapFormDataToCustomerDraft = (data: FormData): CustomerDraft => {
       country: (data.billingAddress.country || '').toUpperCase(),
     };
     addresses.push(billingAddress);
-    defaultBillingAddress = 1;
+
+    if (data.defaultBillingAddress) {
+      defaultBillingAddress = addresses.length - 1;
+    }
+  } else if (data.useSameAddress) {
+    defaultBillingAddress = defaultShippingAddress;
   }
 
   return {
@@ -231,3 +249,4 @@ export const mapFormDataToCustomerDraft = (data: FormData): CustomerDraft => {
     defaultBillingAddress,
   };
 };
+

--- a/src/components/registration-form/registration-form.tsx
+++ b/src/components/registration-form/registration-form.tsx
@@ -7,12 +7,14 @@ import type { CustomerDraft } from '@commercetools/platform-sdk';
 import { registerCustomer } from 'src/api/customers-api';
 import { useNavigate } from 'react-router-dom';
 import { getErrorMessage, showErrorToast } from '@utils/utils';
+import { countries } from '@utils/countries-const';
 
 export const RegistrationForm: FC = () => {
   const navigate = useNavigate();
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isValid, isDirty },
   } = useForm<FormData>({
     mode: 'all',
@@ -34,7 +36,7 @@ export const RegistrationForm: FC = () => {
       } else showErrorToast(getErrorMessage(error), 'rgb(255, 95, 110');
     }
   };
-
+  const useSameAddress = watch('useSameAddress');
   return (
     <form className={styles.registrationForm} onSubmit={event => void handleSubmit(onSubmit)(event)}>
       <div className={styles.registrationInputContainer}>
@@ -74,45 +76,120 @@ export const RegistrationForm: FC = () => {
         />
         {errors.dateOfBirth && <p className={styles.errorMessage}>{errors.dateOfBirth.message}</p>}
       </div>
-      <div className={styles.registrationInputContainer}>
-        <input
-          className={styles.registrationInput}
-          {...register('street', validationRules.street)}
-          placeholder="Street"
-        />
-        {errors.street && <p className={styles.errorMessage}>{errors.street.message}</p>}
+      {/* Shipping Address */}
+      <div className={`${styles.shippingAddressContainer} ${styles.addressContainer}`}>
+        <h3>Shipping Address</h3>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            {...register('shippingAddress.street', validationRules.street)}
+            placeholder="Street"
+          />
+          {errors.shippingAddress?.street && (
+            <p className={styles.errorMessage}>{errors.shippingAddress.street.message}</p>
+          )}
+        </div>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            {...register('shippingAddress.city', validationRules.city)}
+            placeholder="City"
+          />
+          {errors.shippingAddress?.city && <p className={styles.errorMessage}>{errors.shippingAddress.city.message}</p>}
+        </div>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            {...register('shippingAddress.postalCode', validationRules.postalCode)}
+            placeholder="Postal Code"
+          />
+          {errors.shippingAddress?.postalCode && (
+            <p className={styles.errorMessage}>{errors.shippingAddress.postalCode.message}</p>
+          )}
+        </div>
+        <div className={styles.registrationInputContainer}>
+          <select
+            className={styles.registrationInput}
+            {...register('shippingAddress.country', validationRules.country)}
+            defaultValue=""
+          >
+            <option value="" disabled>
+              Select Country
+            </option>
+            {countries.map(({ code, name }) => (
+              <option key={code} value={code}>
+                {code} - {name}
+              </option>
+            ))}
+          </select>
+          {errors.shippingAddress?.country && (
+            <p className={styles.errorMessage}>{errors.shippingAddress.country.message}</p>
+          )}
+        </div>
       </div>
+
+      {/* Checkbox for using shipping address as billing address */}
       <div className={styles.registrationInputContainer}>
-        <input className={styles.registrationInput} {...register('city', validationRules.city)} placeholder="City" />
-        {errors.city && <p className={styles.errorMessage}>{errors.city.message}</p>}
+        <label className={styles.singleAddressFlag}>
+          <input type="checkbox" {...register('useSameAddress')} />
+          Use shipping address as billing address
+        </label>
       </div>
-      <div className={styles.registrationInputContainer}>
-        <input
-          className={styles.registrationInput}
-          {...register('postalCode', validationRules.postalCode)}
-          placeholder="Postal Code"
-        />
-        {errors.postalCode && <p className={styles.errorMessage}>{errors.postalCode.message}</p>}
-      </div>
-      <div className={styles.registrationInputContainer}>
-        <select className={styles.registrationInput} {...register('country', validationRules.country)} defaultValue="">
-          <option value="" disabled>
-            Select Country
-          </option>
-          <option value="US">US - United States</option>
-          <option value="GB">GB - Great Britain</option>
-          <option value="DE">DE - Germany</option>
-          <option value="FR">FR - France</option>
-          <option value="IT">IT - Italy</option>
-          <option value="FI">FI - Finland</option>
-          <option value="ES">ES - Spain</option>
-          <option value="NL">NL - Netherlands</option>
-          <option value="CA">CA - Canada</option>
-          <option value="AU">AU - Australia</option>
-          <option value="CZ">CZ - Czech Republic</option>
-        </select>
-        {errors.country && <p className={styles.errorMessage}>{errors.country.message}</p>}
-      </div>
+
+      {/* Billing Address */}
+      {!useSameAddress && (
+        <div className={`${styles.billingAddressContainer} ${styles.addressContainer}`}>
+          <h3>Billing Address</h3>
+          <div className={styles.registrationInputContainer}>
+            <input
+              className={styles.registrationInput}
+              {...register('billingAddress.street', validationRules.street)}
+              placeholder="Street"
+            />
+            {errors.billingAddress?.street && (
+              <p className={styles.errorMessage}>{errors.billingAddress.street.message}</p>
+            )}
+          </div>
+          <div className={styles.registrationInputContainer}>
+            <input
+              className={styles.registrationInput}
+              {...register('billingAddress.city', validationRules.city)}
+              placeholder="City"
+            />
+            {errors.billingAddress?.city && <p className={styles.errorMessage}>{errors.billingAddress.city.message}</p>}
+          </div>
+          <div className={styles.registrationInputContainer}>
+            <input
+              className={styles.registrationInput}
+              {...register('billingAddress.postalCode', validationRules.postalCode)}
+              placeholder="Postal Code"
+            />
+            {errors.billingAddress?.postalCode && (
+              <p className={styles.errorMessage}>{errors.billingAddress.postalCode.message}</p>
+            )}
+          </div>
+          <div className={styles.registrationInputContainer}>
+            <select
+              className={styles.registrationInput}
+              {...register('billingAddress.country', validationRules.country)}
+              defaultValue=""
+            >
+              <option value="" disabled>
+                Select Country
+              </option>
+              {countries.map(({ code, name }) => (
+                <option key={code} value={code}>
+                  {code} - {name}
+                </option>
+              ))}
+            </select>
+            {errors.billingAddress?.country && (
+              <p className={styles.errorMessage}>{errors.billingAddress.country.message}</p>
+            )}
+          </div>
+        </div>
+      )}
+
       <button className={styles.registrationButton} type="submit" disabled={!isDirty || !isValid}>
         Register
       </button>
@@ -120,20 +197,37 @@ export const RegistrationForm: FC = () => {
   );
 };
 
-export const mapFormDataToCustomerDraft = (data: FormData): CustomerDraft => ({
-  email: data.email,
-  password: data.password,
-  firstName: data.firstName,
-  lastName: data.lastName,
-  dateOfBirth: data.dateOfBirth,
-  addresses: [
-    {
-      streetName: data.street,
-      city: data.city,
-      postalCode: data.postalCode,
-      country: data.country.toUpperCase(),
-    },
-  ],
-  defaultShippingAddress: 0,
-  defaultBillingAddress: 0,
-});
+export const mapFormDataToCustomerDraft = (data: FormData): CustomerDraft => {
+  const shippingAddress = {
+    streetName: data.shippingAddress.street,
+    city: data.shippingAddress.city,
+    postalCode: data.shippingAddress.postalCode,
+    country: data.shippingAddress.country.toUpperCase(),
+  };
+
+  const addresses = [shippingAddress];
+  let defaultShippingAddress = 0;
+  let defaultBillingAddress = 0;
+
+  if (!data.useSameAddress && data.billingAddress.street) {
+    const billingAddress = {
+      streetName: data.billingAddress.street,
+      city: data.billingAddress.city || '',
+      postalCode: data.billingAddress.postalCode || '',
+      country: (data.billingAddress.country || '').toUpperCase(),
+    };
+    addresses.push(billingAddress);
+    defaultBillingAddress = 1;
+  }
+
+  return {
+    email: data.email,
+    password: data.password,
+    firstName: data.firstName,
+    lastName: data.lastName,
+    dateOfBirth: data.dateOfBirth,
+    addresses,
+    defaultShippingAddress,
+    defaultBillingAddress,
+  };
+};

--- a/src/components/registration-form/registration-form.tsx
+++ b/src/components/registration-form/registration-form.tsx
@@ -85,10 +85,6 @@ export const RegistrationForm: FC = () => {
       {/* Shipping Address */}
       <div className={`${styles.shippingAddressContainer} ${styles.formBlockContainer}`}>
         <h3>Shipping Address</h3>
-        <label className={styles.checkboxLabel}>
-          <input type="checkbox" {...register('defaultShippingAddress')} />
-          Set this address as default shipping address
-        </label>
         <div className={styles.registrationInputContainer}>
           <input
             className={styles.registrationInput}
@@ -136,6 +132,10 @@ export const RegistrationForm: FC = () => {
             <p className={styles.errorMessage}>{errors.shippingAddress.country.message}</p>
           )}
         </div>
+        <label className={styles.checkboxLabel}>
+          <input type="checkbox" {...register('defaultShippingAddress')} />
+          Set this address as default shipping address
+        </label>
       </div>
       {/* Checkbox for using shipping address as billing address */}
       <div className={styles.registrationInputContainer}>
@@ -148,10 +148,6 @@ export const RegistrationForm: FC = () => {
       {!useSameAddress && (
         <div className={`${styles.billingAddressContainer} ${styles.formBlockContainer}`}>
           <h3>Billing Address</h3>
-          <label className={styles.checkboxLabel}>
-            <input type="checkbox" {...register('defaultBillingAddress')} />
-            Set this address as default billing address
-          </label>
           <div className={styles.registrationInputContainer}>
             <input
               className={styles.registrationInput}
@@ -199,6 +195,10 @@ export const RegistrationForm: FC = () => {
               <p className={styles.errorMessage}>{errors.billingAddress.country.message}</p>
             )}
           </div>
+          <label className={styles.checkboxLabel}>
+            <input type="checkbox" {...register('defaultBillingAddress')} />
+            Set this address as default billing address
+          </label>
         </div>
       )}
       <button className={styles.registrationButton} type="submit" disabled={!isDirty || !isValid}>

--- a/src/components/registration-form/registration-form.tsx
+++ b/src/components/registration-form/registration-form.tsx
@@ -79,7 +79,7 @@ export const RegistrationForm: FC = () => {
       {/* Shipping Address */}
       <div className={`${styles.shippingAddressContainer} ${styles.addressContainer}`}>
         <h3>Shipping Address</h3>
-        <label className={styles.defaultAddressCheckbox}>
+        <label className={styles.checkboxLabel}>
           <input type="checkbox" {...register('defaultShippingAddress')} />
           Set this address as default shipping address
         </label>
@@ -134,7 +134,7 @@ export const RegistrationForm: FC = () => {
 
       {/* Checkbox for using shipping address as billing address */}
       <div className={styles.registrationInputContainer}>
-        <label className={styles.singleAddressFlag}>
+        <label className={styles.checkboxLabel}>
           <input type="checkbox" {...register('useSameAddress')} />
           Use shipping address as billing address
         </label>
@@ -144,7 +144,7 @@ export const RegistrationForm: FC = () => {
       {!useSameAddress && (
         <div className={`${styles.billingAddressContainer} ${styles.addressContainer}`}>
           <h3>Billing Address</h3>
-          <label className={styles.defaultAddressCheckbox}>
+          <label className={styles.checkboxLabel}>
             <input type="checkbox" {...register('defaultBillingAddress')} />
             Set this address as default billing address
           </label>

--- a/src/components/registration-form/registration-form.tsx
+++ b/src/components/registration-form/registration-form.tsx
@@ -39,45 +39,51 @@ export const RegistrationForm: FC = () => {
   const useSameAddress = watch('useSameAddress');
   return (
     <form className={styles.registrationForm} onSubmit={event => void handleSubmit(onSubmit)(event)}>
-      <div className={styles.registrationInputContainer}>
-        <input className={styles.registrationInput} {...register('email', validationRules.email)} placeholder="Email" />
-        {errors.email && <p className={styles.errorMessage}>{errors.email.message}</p>}
-      </div>
-      <div className={styles.registrationInputContainer}>
-        <input
-          className={styles.registrationInput}
-          {...register('password', validationRules.password)}
-          placeholder="Password"
-        />
-        {errors.password && <p className={styles.errorMessage}>{errors.password.message}</p>}
-      </div>
-      <div className={styles.registrationInputContainer}>
-        <input
-          className={styles.registrationInput}
-          {...register('firstName', validationRules.name)}
-          placeholder="First Name"
-        />
-        {errors.firstName && <p className={styles.errorMessage}>{errors.firstName.message}</p>}
-      </div>
-      <div className={styles.registrationInputContainer}>
-        <input
-          className={styles.registrationInput}
-          {...register('lastName', validationRules.name)}
-          placeholder="Last Name"
-        />
-        {errors.lastName && <p className={styles.errorMessage}>{errors.lastName.message}</p>}
-      </div>
-      <div className={styles.registrationInputContainer}>
-        <input
-          className={styles.registrationInput}
-          type="date"
-          {...register('dateOfBirth', validationRules.dateOfBirth)}
-          placeholder="Date of Birth"
-        />
-        {errors.dateOfBirth && <p className={styles.errorMessage}>{errors.dateOfBirth.message}</p>}
+      <div className={`${styles.mainInfoContainer}  ${styles.formBlockContainer}`}>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            {...register('email', validationRules.email)}
+            placeholder="Email"
+          />
+          {errors.email && <p className={styles.errorMessage}>{errors.email.message}</p>}
+        </div>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            {...register('password', validationRules.password)}
+            placeholder="Password"
+          />
+          {errors.password && <p className={styles.errorMessage}>{errors.password.message}</p>}
+        </div>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            {...register('firstName', validationRules.name)}
+            placeholder="First Name"
+          />
+          {errors.firstName && <p className={styles.errorMessage}>{errors.firstName.message}</p>}
+        </div>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            {...register('lastName', validationRules.name)}
+            placeholder="Last Name"
+          />
+          {errors.lastName && <p className={styles.errorMessage}>{errors.lastName.message}</p>}
+        </div>
+        <div className={styles.registrationInputContainer}>
+          <input
+            className={styles.registrationInput}
+            type="date"
+            {...register('dateOfBirth', validationRules.dateOfBirth)}
+            placeholder="Date of Birth"
+          />
+          {errors.dateOfBirth && <p className={styles.errorMessage}>{errors.dateOfBirth.message}</p>}
+        </div>
       </div>
       {/* Shipping Address */}
-      <div className={`${styles.shippingAddressContainer} ${styles.addressContainer}`}>
+      <div className={`${styles.shippingAddressContainer} ${styles.formBlockContainer}`}>
         <h3>Shipping Address</h3>
         <label className={styles.checkboxLabel}>
           <input type="checkbox" {...register('defaultShippingAddress')} />
@@ -131,7 +137,6 @@ export const RegistrationForm: FC = () => {
           )}
         </div>
       </div>
-
       {/* Checkbox for using shipping address as billing address */}
       <div className={styles.registrationInputContainer}>
         <label className={styles.checkboxLabel}>
@@ -139,10 +144,9 @@ export const RegistrationForm: FC = () => {
           Use shipping address as billing address
         </label>
       </div>
-
       {/* Billing Address */}
       {!useSameAddress && (
-        <div className={`${styles.billingAddressContainer} ${styles.addressContainer}`}>
+        <div className={`${styles.billingAddressContainer} ${styles.formBlockContainer}`}>
           <h3>Billing Address</h3>
           <label className={styles.checkboxLabel}>
             <input type="checkbox" {...register('defaultBillingAddress')} />
@@ -197,7 +201,6 @@ export const RegistrationForm: FC = () => {
           </div>
         </div>
       )}
-
       <button className={styles.registrationButton} type="submit" disabled={!isDirty || !isValid}>
         Register
       </button>
@@ -249,4 +252,3 @@ export const mapFormDataToCustomerDraft = (data: FormData): CustomerDraft => {
     defaultBillingAddress,
   };
 };
-

--- a/src/components/registration-form/registration-form.tsx
+++ b/src/components/registration-form/registration-form.tsx
@@ -95,11 +95,22 @@ export const RegistrationForm: FC = () => {
         {errors.postalCode && <p className={styles.errorMessage}>{errors.postalCode.message}</p>}
       </div>
       <div className={styles.registrationInputContainer}>
-        <input
-          className={styles.registrationInput}
-          {...register('country', validationRules.country)}
-          placeholder="Country"
-        />
+        <select className={styles.registrationInput} {...register('country', validationRules.country)} defaultValue="">
+          <option value="" disabled>
+            Select Country
+          </option>
+          <option value="US">US - United States</option>
+          <option value="GB">GB - Great Britain</option>
+          <option value="DE">DE - Germany</option>
+          <option value="FR">FR - France</option>
+          <option value="IT">IT - Italy</option>
+          <option value="FI">FI - Finland</option>
+          <option value="ES">ES - Spain</option>
+          <option value="NL">NL - Netherlands</option>
+          <option value="CA">CA - Canada</option>
+          <option value="AU">AU - Australia</option>
+          <option value="CZ">CZ - Czech Republic</option>
+        </select>
         {errors.country && <p className={styles.errorMessage}>{errors.country.message}</p>}
       </div>
       <button className={styles.registrationButton} type="submit" disabled={!isDirty || !isValid}>

--- a/src/components/registration-form/registration-form.types.ts
+++ b/src/components/registration-form/registration-form.types.ts
@@ -1,12 +1,23 @@
-
 export type FormData = {
   email: string;
   password: string;
   firstName: string;
   lastName: string;
   dateOfBirth: string;
-  street: string;
-  city: string;
-  postalCode: string;
-  country: string;
+
+  shippingAddress: {
+    street: string;
+    city: string;
+    postalCode: string;
+    country: string;
+  };
+
+  billingAddress: {
+    street?: string;
+    city?: string;
+    postalCode?: string;
+    country?: string;
+  };
+
+  useSameAddress: boolean;
 };

--- a/src/components/registration-form/registration-form.types.ts
+++ b/src/components/registration-form/registration-form.types.ts
@@ -20,4 +20,6 @@ export type FormData = {
   };
 
   useSameAddress: boolean;
+  defaultShippingAddress: boolean;
+  defaultBillingAddress: boolean;
 };

--- a/src/pages/registration/registration.module.css
+++ b/src/pages/registration/registration.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  height: 100vh;
+  min-height: 100vh;
   background-color: #f0f0f0;
   gap: 20px;
 }

--- a/src/utils/countries-const.ts
+++ b/src/utils/countries-const.ts
@@ -1,0 +1,13 @@
+export const countries = [
+    { code: 'US', name: 'United States' },
+    { code: 'GB', name: 'Great Britain' },
+    { code: 'DE', name: 'Germany' },
+    { code: 'FR', name: 'France' },
+    { code: 'IT', name: 'Italy' },
+    { code: 'FI', name: 'Finland' },
+    { code: 'ES', name: 'Spain' },
+    { code: 'NL', name: 'Netherlands' },
+    { code: 'CA', name: 'Canada' },
+    { code: 'AU', name: 'Australia' },
+    { code: 'CZ', name: 'Czech Republic' },
+  ];

--- a/src/utils/validation-rules.ts
+++ b/src/utils/validation-rules.ts
@@ -47,19 +47,16 @@ export const validationRules = {
   postalCode: {
     required: 'Postal code is required',
     pattern: {
-      //TO DO: implement valid regex for postal code after API finishing
-      value: /^[\d A-Za-z-]+$/,
-      message:
-        'Postal code must follow the format for the country (e.g., 12345 or A1B 2C3 for the U.S. and Canada, respectively)',
+      value: /^[\d\sA-Za-z-]{3,10}$/,
+      message: 'Postal code must be 3–10 characters and may contain letters, numbers, spaces, or dashes',
     },
   },
 
   country: {
     required: 'Country is required',
     pattern: {
-      // TO DO: Replace with ISO country code validation from API/autocomplete
-      value: /^[\sA-Za-z-]{2,}$/,
-      message: 'Country name must contain only letters and be at least 2 characters long',
+      value: /^[A-Z]{2}$/,
+      message: 'Country must be a valid 2-letter ISO code (e.g., US, GB, DE)',
     },
   },
 };


### PR DESCRIPTION
1. Task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%232.md)
2. Screenshot 
![image](https://github.com/user-attachments/assets/97b8b859-b2ec-43b4-b4dd-897b87b649d7)

3. Deploy: -
4. Done 19.05.2025 / deadline -
5. Score: 30
 - [x] 🏠 (15 points) Allow users to set a default address during registration. [RSS-ECOMM-2_14](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_14.md)
 - [x] 🏠 (15 points) Enable users to select different billing and shipping addresses or choose a single address for both billing and shipping during the registration process. [RSS-ECOMM-2_15](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_15.md)
